### PR TITLE
add: cleanup for unverified users using node-cron scheduler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,10 +13,12 @@
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
+        "express-rate-limit": "^7.5.0",
         "firebase-admin": "^13.4.0",
         "google-auth-library": "^9.15.1",
         "jsonwebtoken": "^9.0.2",
         "mysql2": "^3.14.0",
+        "node-cron": "^4.1.0",
         "nodemailer": "^7.0.3",
         "nodemon": "^3.1.9"
       }
@@ -1141,6 +1143,21 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/express-rate-limit": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+      "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": "^4.11 || 5 || ^5.0.0-beta.1"
+      }
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -2106,6 +2123,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-cron": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/node-cron/-/node-cron-4.1.0.tgz",
+      "integrity": "sha512-OS+3ORu+h03/haS6Di8Qr7CrVs4YaKZZOynZwQpyPZDnR3tqRbwJmuP2gVR16JfhLgyNlloAV1VTrrWlRogCFA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/node-fetch": {

--- a/package.json
+++ b/package.json
@@ -15,10 +15,12 @@
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
+    "express-rate-limit": "^7.5.0",
     "firebase-admin": "^13.4.0",
     "google-auth-library": "^9.15.1",
     "jsonwebtoken": "^9.0.2",
     "mysql2": "^3.14.0",
+    "node-cron": "^4.1.0",
     "nodemailer": "^7.0.3",
     "nodemon": "^3.1.9"
   }

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -11,8 +11,24 @@ const {
   logoutHandler,
 } = require("../controllers/authController");
 const { authenticateToken } = require("../middlewares/auth");
+const rateLimit = require("express-rate-limit");
 
-router.post("/signup", signup);
+// Rate limiter for signup endpoint: 5 attempts per 15 minutes per IP
+const signupLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  max: 5,
+  message:
+    "Too many signup attempts from this IP, please try again after 15 minutes.",
+});
+
+// Rate limiter for resend-code endpoint: 3 attempts per 5 minutes per IP
+const resendCodeLimiter = rateLimit({
+  windowMs: 5 * 60 * 1000,
+  max: 3,
+  message: "Too many resend attempts, please try again after 5 minutes.",
+});
+
+router.post("/signup", signupLimiter, signup);
 
 router.post("/verify-code", verifyCodeHandler);
 
@@ -25,7 +41,7 @@ router.get("/", authenticateToken, (req, res) =>
   res.status(200).json({ message: "Protected route", user: req.user })
 );
 
-router.post("/resend-code", resendCodeHandler);
+router.post("/resend-code", resendCodeLimiter, resendCodeHandler);
 
 router.post("/refresh-token", refreshTokenHandler);
 

--- a/server.js
+++ b/server.js
@@ -2,6 +2,8 @@ const express = require("express");
 const cookieParser = require("cookie-parser");
 const cors = require("cors");
 require("dotenv").config();
+const cron = require("node-cron");
+const { cleanupUnverifiedUsers } = require("./services/authService");
 
 const app = express();
 
@@ -23,6 +25,15 @@ app.use(express.urlencoded({ extended: true }));
 // Routes
 const authRoutes = require("./routes/authRoutes");
 app.use("/api/auth", authRoutes);
+
+cron.schedule("0 0 * * *", async () => {
+  console.log("Running scheduled cleanup of unverified users...");
+  try {
+    await cleanupUnverifiedUsers();
+  } catch (error) {
+    console.error("Crob job error:  ", error.message);
+  }
+});
 
 // Start server
 const PORT = 5000;

--- a/services/authService.js
+++ b/services/authService.js
@@ -321,19 +321,24 @@ const resendCode = async (email) => {
   }
 };
 
-
 const cleanupUnverifiedUsers = async () => {
-  const connection = pool.getConnection();
-  
+  let connection;
+
   try {
+    connection = await pool.getConnection();
     console.log("Cleaning the users which have not verified...");
     const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
     const [deletedUsers] = await connection.query(
       "DELETE FROM users WHERE verified = FALSE AND created_at < ?",
       [oneDayAgo]
-    )
+    );
+    console.log(`Deleted ${deletedUsers.affectedRows} unverified users.`);
+  } catch (error) {
+    console.error("Cleanup unverified users error", error.message);
+  } finally {
+    if (connection) connection.release();
   }
-}
+};
 
 module.exports = {
   initiateSignUp,
@@ -343,4 +348,5 @@ module.exports = {
   verifyGoogle,
   generateTokens,
   resendCode,
+  cleanupUnverifiedUsers,
 };


### PR DESCRIPTION
Added:
- A service "cleanupUnverifiedUsers" and calling using node-cron scheduler every night in 00:00, to delete from users table the users which did not pass the verifyCode page and did not get verified in 24 hours. We chose to register the user immediately after he writes his email in the sign up form to be more straightforward, to avoid a pending_users table, to prevent a signup duplication so you cannot start 2 signup processes with a same email or maybe just when the users get's out of verifyCode page, it notifies him to go through login at that point. Since we've approached the passwordless method with email-based flow, lot's of companies also do the same.
- Since the database can be cluttered from spamming, we added a signup limiter with the library: express-rate-limit, and we limited the signup endpoind to 5 attemps per 15 minutes per IP and also a rate limiter for the resend-code endpoint, 3 attempts per 5 minutes per IP. 
Discussion: We thought of reCAPTCHA too but since the app is supposed not to have any big risk of breaching data or maybe as an app with high-risk of spamming, we didn't integrate for better UX of the user. We excluded the friction of the user with reCAPTCHA but adding a controller for the future if we mark a lot of spamming from the same IP address, we could reassess reCAPTCHA.